### PR TITLE
bug fix: duplicate recipient emails

### DIFF
--- a/packages/graphql-server/index.ts
+++ b/packages/graphql-server/index.ts
@@ -433,8 +433,7 @@ const resolvers = {
         LEFT JOIN recipient_emails re ON re.email_address = t.email
         WHERE re.email_address IS NULL
         RETURNING *;
-        
-  `;
+        `;
         values = [campaign_id, email_addresses];
       } else {
         // Generate the bulk insert query and values
@@ -445,7 +444,7 @@ const resolvers = {
           .join(", ")}
         ON CONFLICT ON CONSTRAINT unique_campaign_email DO NOTHING
         RETURNING *;
-      `;
+        `;
 
         values = [campaign_id, ...email_addresses];
       }


### PR DESCRIPTION
- dont add duplicate recipient emails in the same campaign
- backend conditional logic on whether to add emails that exist in other campaigns or not